### PR TITLE
fix: parse Clash HTTPUpgrade ws option

### DIFF
--- a/Proxylink/pkg/generator/singbox.go
+++ b/Proxylink/pkg/generator/singbox.go
@@ -87,7 +87,7 @@ type SingboxTransport struct {
 	Type        string            `json:"type"`
 	Path        string            `json:"path,omitempty"`
 	Headers     map[string]string `json:"headers,omitempty"`
-	Host        []string          `json:"host,omitempty"`
+	Host        any               `json:"host,omitempty"`
 	ServiceName string            `json:"service_name,omitempty"`
 }
 
@@ -253,7 +253,7 @@ func buildSingboxTransport(p *model.ProfileItem) *SingboxTransport {
 			t.Path = "/"
 		}
 		if p.Host != "" {
-			t.Headers = map[string]string{"Host": p.Host}
+			t.Host = p.Host
 		}
 	default:
 		return nil

--- a/Proxylink/pkg/generator/singbox_test.go
+++ b/Proxylink/pkg/generator/singbox_test.go
@@ -1,0 +1,70 @@
+package generator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"proxylink/pkg/model"
+)
+
+func TestGenerateSingboxHTTPUpgradeTransportHost(t *testing.T) {
+	profile := model.NewProfileItem(model.VLESS)
+	profile.Remarks = "upgrade-node"
+	profile.Server = "example.com"
+	profile.ServerPort = "443"
+	profile.Password = "00000000-0000-0000-0000-000000000000"
+	profile.Network = "httpupgrade"
+	profile.Path = "/upgrade"
+	profile.Host = "cdn.example.com"
+
+	output, err := GenerateSingboxOutbound(profile)
+	if err != nil {
+		t.Fatalf("GenerateSingboxOutbound() error = %v", err)
+	}
+
+	var config map[string][]map[string]any
+	if err := json.Unmarshal([]byte(output), &config); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	transport := config["outbounds"][0]["transport"].(map[string]any)
+	if transport["type"] != "httpupgrade" {
+		t.Fatalf("transport.type = %v, want httpupgrade", transport["type"])
+	}
+	if transport["host"] != "cdn.example.com" {
+		t.Fatalf("transport.host = %v, want cdn.example.com", transport["host"])
+	}
+	if _, ok := transport["headers"]; ok {
+		t.Fatalf("transport.headers should be omitted for HTTPUpgrade host: %v", transport["headers"])
+	}
+}
+
+func TestGenerateSingboxHTTPTransportHostArray(t *testing.T) {
+	profile := model.NewProfileItem(model.VLESS)
+	profile.Remarks = "http-node"
+	profile.Server = "example.com"
+	profile.ServerPort = "443"
+	profile.Password = "00000000-0000-0000-0000-000000000000"
+	profile.Network = "h2"
+	profile.Path = "/h2"
+	profile.Host = "a.example.com,b.example.com"
+
+	output, err := GenerateSingboxOutbound(profile)
+	if err != nil {
+		t.Fatalf("GenerateSingboxOutbound() error = %v", err)
+	}
+
+	var config map[string][]map[string]any
+	if err := json.Unmarshal([]byte(output), &config); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	transport := config["outbounds"][0]["transport"].(map[string]any)
+	hosts, ok := transport["host"].([]any)
+	if !ok {
+		t.Fatalf("transport.host = %T, want array", transport["host"])
+	}
+	if len(hosts) != 2 || hosts[0] != "a.example.com" || hosts[1] != "b.example.com" {
+		t.Fatalf("transport.host = %v, want [a.example.com b.example.com]", hosts)
+	}
+}

--- a/Proxylink/pkg/parser/clash.go
+++ b/Proxylink/pkg/parser/clash.go
@@ -82,8 +82,9 @@ type ClashRealityOpts struct {
 }
 
 type ClashWsOpts struct {
-	Path    string            `yaml:"path"`
-	Headers map[string]string `yaml:"headers"`
+	Path             string            `yaml:"path"`
+	Headers          map[string]string `yaml:"headers"`
+	V2rayHTTPUpgrade bool              `yaml:"v2ray-http-upgrade"`
 }
 
 type ClashGrpcOpts struct {
@@ -268,6 +269,9 @@ func parseClashTransport(cp *ClashProxy, p *model.ProfileItem) {
 	switch p.Network {
 	case "ws":
 		if cp.WsOpts != nil {
+			if cp.WsOpts.V2rayHTTPUpgrade {
+				p.Network = "httpupgrade"
+			}
 			p.Path = cp.WsOpts.Path
 			if host, ok := cp.WsOpts.Headers["Host"]; ok {
 				p.Host = host

--- a/Proxylink/pkg/parser/clash_test.go
+++ b/Proxylink/pkg/parser/clash_test.go
@@ -1,0 +1,65 @@
+package parser
+
+import "testing"
+
+func TestParseClashConfigV2rayHTTPUpgrade(t *testing.T) {
+	data := []byte(`
+proxies:
+  - name: upgrade-node
+    type: vless
+    server: example.com
+    port: 443
+    uuid: 00000000-0000-0000-0000-000000000000
+    network: ws
+    tls: true
+    ws-opts:
+      path: /upgrade
+      headers:
+        Host: cdn.example.com
+      v2ray-http-upgrade: true
+`)
+
+	profiles, err := ParseClashConfig(data)
+	if err != nil {
+		t.Fatalf("ParseClashConfig() error = %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("ParseClashConfig() returned %d profiles, want 1", len(profiles))
+	}
+
+	profile := profiles[0]
+	if profile.Network != "httpupgrade" {
+		t.Fatalf("Network = %q, want %q", profile.Network, "httpupgrade")
+	}
+	if profile.Path != "/upgrade" {
+		t.Fatalf("Path = %q, want %q", profile.Path, "/upgrade")
+	}
+	if profile.Host != "cdn.example.com" {
+		t.Fatalf("Host = %q, want %q", profile.Host, "cdn.example.com")
+	}
+}
+
+func TestParseClashConfigWebSocketWithoutHTTPUpgrade(t *testing.T) {
+	data := []byte(`
+proxies:
+  - name: ws-node
+    type: vless
+    server: example.com
+    port: 443
+    uuid: 00000000-0000-0000-0000-000000000000
+    network: ws
+    ws-opts:
+      path: /ws
+`)
+
+	profiles, err := ParseClashConfig(data)
+	if err != nil {
+		t.Fatalf("ParseClashConfig() error = %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("ParseClashConfig() returned %d profiles, want 1", len(profiles))
+	}
+	if profiles[0].Network != "ws" {
+		t.Fatalf("Network = %q, want %q", profiles[0].Network, "ws")
+	}
+}

--- a/Proxylink/pkg/parser/singbox.go
+++ b/Proxylink/pkg/parser/singbox.go
@@ -154,8 +154,17 @@ func fromSingboxOutbound(ob *generator.SingboxOutbound) *model.ProfileItem {
 		}
 
 		switch p.Network {
-		case "ws", "httpupgrade":
+		case "ws":
 			if ob.Transport.Headers != nil {
+				if host, ok := ob.Transport.Headers["Host"]; ok {
+					p.Host = host
+				} else if host, ok := ob.Transport.Headers["host"]; ok {
+					p.Host = host
+				}
+			}
+		case "httpupgrade":
+			p.Host = singboxTransportHostString(ob.Transport.Host)
+			if p.Host == "" && ob.Transport.Headers != nil {
 				if host, ok := ob.Transport.Headers["Host"]; ok {
 					p.Host = host
 				} else if host, ok := ob.Transport.Headers["host"]; ok {
@@ -165,9 +174,7 @@ func fromSingboxOutbound(ob *generator.SingboxOutbound) *model.ProfileItem {
 		case "grpc":
 			p.ServiceName = ob.Transport.ServiceName
 		case "h2", "http":
-			if len(ob.Transport.Host) > 0 {
-				p.Host = strings.Join(ob.Transport.Host, ",")
-			}
+			p.Host = singboxTransportHostString(ob.Transport.Host)
 		}
 	}
 
@@ -216,4 +223,23 @@ func fromSingboxOutbound(ob *generator.SingboxOutbound) *model.ProfileItem {
 	}
 
 	return p
+}
+
+func singboxTransportHostString(host any) string {
+	switch value := host.(type) {
+	case string:
+		return value
+	case []string:
+		return strings.Join(value, ",")
+	case []any:
+		hosts := make([]string, 0, len(value))
+		for _, item := range value {
+			if host, ok := item.(string); ok && host != "" {
+				hosts = append(hosts, host)
+			}
+		}
+		return strings.Join(hosts, ",")
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
## Summary
- parse Clash `ws-opts.v2ray-http-upgrade: true`
- map Mihomo/Clash HTTPUpgrade WebSocket nodes to internal `httpupgrade`
- generate sing-box HTTPUpgrade transport with standalone `host` field, matching sing-box docs
- keep existing WebSocket behavior unchanged when the option is absent

## Tests
- `go test ./...`
- converted a Clash YAML sample with `v2ray-http-upgrade: true`; output transport was `{ "type": "httpupgrade", "path": "/upgrade", "host": "cdn.example.com" }`

Related to Fanju6/NetProxy-Magisk#158.