### PR TITLE
fix: preserve subscription node order in multi-file output

### DIFF
--- a/Proxylink/main.go
+++ b/Proxylink/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"proxylink/pkg/encoder"
@@ -238,6 +239,10 @@ func writeMultipleFiles(profiles []*model.ProfileItem) error {
 
 	ext := getFileExtension()
 	usedNames := make(map[string]int) // 跟踪已使用的文件名，避免重名覆盖
+	orderWidth := len(strconv.Itoa(len(profiles)))
+	if orderWidth < 4 {
+		orderWidth = 4
+	}
 
 	for i, profile := range profiles {
 		// 生成文件名
@@ -272,6 +277,7 @@ func writeMultipleFiles(profiles []*model.ProfileItem) error {
 		}
 
 		filename = filename + ext
+		filename = fmt.Sprintf("%0*d_%s", orderWidth, i+1, filename)
 
 		filepath := filepath.Join(*outputDir, filename)
 		if err := os.WriteFile(filepath, []byte(output), 0644); err != nil {

--- a/Proxylink/main_test.go
+++ b/Proxylink/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"proxylink/pkg/model"
+)
+
+func TestWriteMultipleFilesPrefixesFileOrderOnly(t *testing.T) {
+	tempDir := t.TempDir()
+	oldOutputDir := *outputDir
+	oldOutputFormat := *outputFormat
+	t.Cleanup(func() {
+		*outputDir = oldOutputDir
+		*outputFormat = oldOutputFormat
+	})
+
+	*outputDir = tempDir
+	*outputFormat = "singbox"
+
+	profiles := []*model.ProfileItem{
+		testVLESSProfile("US2-Wave-CN2"),
+		testVLESSProfile("US10-Wave-CN2"),
+		testVLESSProfile("US1-Wave-CF"),
+	}
+
+	if err := writeMultipleFiles(profiles); err != nil {
+		t.Fatalf("writeMultipleFiles() error = %v", err)
+	}
+
+	wantFiles := []string{
+		"0001_US2-Wave-CN2.json",
+		"0002_US10-Wave-CN2.json",
+		"0003_US1-Wave-CF.json",
+	}
+	for _, name := range wantFiles {
+		if _, err := os.Stat(filepath.Join(tempDir, name)); err != nil {
+			t.Fatalf("expected output file %s: %v", name, err)
+		}
+	}
+
+	for i, name := range wantFiles {
+		tag := readSingleSingboxTag(t, filepath.Join(tempDir, name))
+		if tag != profiles[i].Remarks {
+			t.Fatalf("%s tag = %q, want %q", name, tag, profiles[i].Remarks)
+		}
+	}
+}
+
+func testVLESSProfile(name string) *model.ProfileItem {
+	profile := model.NewProfileItem(model.VLESS)
+	profile.Remarks = name
+	profile.Server = "example.com"
+	profile.ServerPort = "443"
+	profile.Password = "00000000-0000-0000-0000-000000000000"
+	return profile
+}
+
+func readSingleSingboxTag(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%s) error = %v", path, err)
+	}
+
+	var config struct {
+		Outbounds []struct {
+			Tag string `json:"tag"`
+		} `json:"outbounds"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("json.Unmarshal(%s) error = %v", path, err)
+	}
+	if len(config.Outbounds) != 1 {
+		t.Fatalf("%s outbounds length = %d, want 1", path, len(config.Outbounds))
+	}
+	return config.Outbounds[0].Tag
+}


### PR DESCRIPTION
## Summary
- Prefix multi-file output filenames with a stable order index so shell glob scanning preserves the original subscription order.
- Keep sing-box outbound tags unchanged, so UI/display names do not include the internal order prefix.
- Add a regression test covering filename order prefixes and unchanged tags.

## Tests
- D:\\tools\\go\\bin\\go.exe test ./...

## Context
NetProxy loads subscription nodes from split JSON files with shell glob order. Without an internal order prefix, names like US10 can be scanned before US2, making the default node order differ from the original Clash subscription order.